### PR TITLE
Refactor: Use HandCardStackView for Both Player and Dealer Hands

### DIFF
--- a/BlackjackGame.xcodeproj/project.pbxproj
+++ b/BlackjackGame.xcodeproj/project.pbxproj
@@ -78,7 +78,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1620;
-				LastUpgradeCheck = 1620;
+				LastUpgradeCheck = 1640;
 				TargetAttributes = {
 					B60A27742D3D2643008885CD = {
 						CreatedOnToolsVersion = 16.2;
@@ -160,6 +160,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = XN6MYS666M;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -223,6 +224,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = XN6MYS666M;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -252,14 +254,12 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"BlackjackGame/Preview Content\"";
-				DEVELOPMENT_TEAM = XN6MYS666M;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -284,14 +284,12 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"BlackjackGame/Preview Content\"";
-				DEVELOPMENT_TEAM = XN6MYS666M;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/BlackjackGame/App/BlackjackGameApp.swift
+++ b/BlackjackGame/App/BlackjackGameApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct BlackjackGameApp: App {
     var body: some Scene {
         WindowGroup {
-            GameView()
+            NewGameView()
         }
     }
 }

--- a/BlackjackGame/GameManager.swift
+++ b/BlackjackGame/GameManager.swift
@@ -1,0 +1,88 @@
+//
+//  GameManager.swift
+//  BlackjackGame
+//
+//  Created by Jonni Akesson on 2025-06-05.
+//
+
+import Foundation
+import Observation
+import SwiftUI
+
+@Observable
+class GameManager {
+    private(set) var playerHand = Hand()
+    private(set) var dealerHand = Hand(isDealer: true)
+    private(set) var deck = Deck()
+    private(set) var gameOver = false
+    private(set) var scoreHistory: [String] = []
+    
+    var statusMessage: String = "♤ BLACKJACK"
+    var hideButtons = false
+    
+    private let dealerCheckDelay: Double = 1.0
+    private let resetDelay: Double = 1.2
+    private let messageDelay: Double = 0.8
+
+    func startGame() {
+        gameOver = false
+        hideButtons = false
+        playerHand.reset()
+        dealerHand.reset()
+        deck.resetDeck()
+        deck.shuffle()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            withAnimation {
+                self.playerHand.addCards(self.deck.deal(2))
+                self.dealerHand.addCards(self.deck.deal(2))
+            }
+        }
+    }
+
+    func playerHit() {
+        playerHand.addCards(deck.deal(1))
+        checkPlayerStatus()
+    }
+
+    func playerStand(completion: @escaping () -> Void) {
+        hideButtons = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+            while self.dealerHand.value < 17 {
+                self.dealerHand.addCards(self.deck.deal(1))
+            }
+            self.evaluateGame()
+            DispatchQueue.main.asyncAfter(deadline: .now() + self.resetDelay) {
+                self.startGame()
+                completion()
+            }
+        }
+    }
+
+    private func checkPlayerStatus() {
+        if playerHand.isBlackjack {
+            statusMessage = "🎉 BLACKJACK! YOU WIN! 🃏🔥"
+            gameOver = true
+            scoreHistory.append("BJ")
+        } else if playerHand.isBusted {
+            statusMessage = "💥 PLAYER BUSTED! 💀"
+            gameOver = true
+            scoreHistory.append("B")
+        }
+    }
+
+    private func evaluateGame() {
+        gameOver = true
+        if dealerHand.isBusted {
+            statusMessage = "🚨 DEALER BUSTED! YOU WIN! 🎉"
+            scoreHistory.append("P")
+        } else if dealerHand.value > playerHand.value {
+            statusMessage = "😞 DEALER WINS."
+            scoreHistory.append("D")
+        } else if dealerHand.value == playerHand.value {
+            statusMessage = "🤝 IT'S A TIE!"
+        } else {
+            statusMessage = "🎊 YOU WIN! 🏆"
+            scoreHistory.append("P")
+        }
+    }
+}

--- a/BlackjackGame/Views/AnimationSpeed.swift
+++ b/BlackjackGame/Views/AnimationSpeed.swift
@@ -1,0 +1,24 @@
+//
+//  AnimationSpeed.swift
+//  BlackjackGame
+//
+//  Created by Jonni Akesson on 2025-06-05.
+//
+
+import Foundation
+
+enum AnimationSpeed: String, CaseIterable, Identifiable {
+    case slow = "Slow"
+    case medium = "Medium"
+    case fast = "Fast"
+
+    var id: String { rawValue }
+
+    var delay: TimeInterval {
+        switch self {
+        case .slow: return 0.6
+        case .medium: return 0.3
+        case .fast: return 0.15
+        }
+    }
+}

--- a/BlackjackGame/Views/CardView.swift
+++ b/BlackjackGame/Views/CardView.swift
@@ -50,7 +50,7 @@ struct CardView: View {
         Image(isFaceUp ? "\(rankName)_\(card.suit)" : "Face_Down_Card")
             .resizable()
             .scaledToFit()
-            .frame(width: 120) // Sets the card size
+            .frame(width: 200) // Sets the card size
             .shadow(radius: 2, x: 2, y: 2) // Adds a slight shadow for depth
     }
 }

--- a/BlackjackGame/Views/DevMenuView.swift
+++ b/BlackjackGame/Views/DevMenuView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct DevMenuView: View {
+    @Binding var animationSpeed: AnimationSpeed
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text("Dev")
+                .font(.caption2)
+                .bold()
+                .foregroundColor(.white.opacity(0.8))
+                .padding(.leading, 6)
+
+            Picker("", selection: $animationSpeed) {
+                ForEach(AnimationSpeed.allCases) { speed in
+                    Text(speed.rawValue.capitalized)
+                        .font(.caption2)
+                        .tag(speed)
+                }
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            .frame(width: 160)
+        }
+        .padding(8)
+        .background(.ultraThinMaterial)
+        .cornerRadius(14)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(Color.white.opacity(0.1), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.15), radius: 4, x: 0, y: 2)
+        .padding(.trailing, 16)
+        .padding(.bottom, 24)
+    
+    }
+}

--- a/BlackjackGame/Views/GameView.swift
+++ b/BlackjackGame/Views/GameView.swift
@@ -1,70 +1,67 @@
-//
-//  GameView.swift
-//  BlackjackGame
-//
-//  Created by Jonni Akesson on 2025-01-19.
-//
-
 import SwiftUI
 
 struct GameView: View {
-    private let initialMessage = "♤ BLACKJACK"
-    private let dealerCheckingMessage = "👀 Dealer is Checking Their Face-Down Card..."
-    private let dealerHasBlackjackMessage = "💀 DEALER HAS BLACKJACK!"
-    private let blackjackWinMessage = "🎉 BLACKJACK! YOU WIN! 🃏🔥"
-    private let playerBustedMessage = "💥 PLAYER BUSTED! 💀"
-    private let dealerBustedMessage = "🚨 DEALER BUSTED! YOU WIN! 🎉"
-    private let playerWinsMessage = "🎊 YOU WIN! 🏆"
-    private let dealerWinsMessage = "😞 DEALER WINS."
-    private let tieMessage = "🤝 IT'S A TIE!"
-    private let bothBlackjackMessage = "🎭 IT'S A TIE! (BOTH HAVE BLACKJACK)"
-    
+    @State private var game = GameManager()
+    @State private var showGameStatus = false
+    @State private var hasGameStarted = false
+
     private let scoreCircleSize: CGFloat = 35
     private let buttonWidth: CGFloat = 140
     private let buttonHeight: CGFloat = 55
     private let dealButtonWidth: CGFloat = 160
-    
-    // Improved Timing for Faster Gameplay Flow
-    private let dealerCheckDelay: Double = 1.0
-    private let resetDelay: Double = 1.2
     private let messageDelay: Double = 0.8
-    private let dealNewCardsDelay: Double = 0.3
-    
-    // MARK: - Properties
-    @State private var playerHand = Hand()
-    @State private var dealerHand = Hand(isDealer: true)
-    @State private var deck = Deck()
-    @State private var gameOver = false
-    @State private var scoreHistory: [String] = []
-    @State private var hideButtons = false
-    @State private var showGameStatus = false // ✅ Controls GameStatusView visibility
-    @State private var statusMessage = "" // ✅ Stores temporary message
-    @State private var message: String = "♤ BLACKJACK" // ✅ Ensures message exists
-    
-    // MARK: - Body
-    
+
     var body: some View {
         ZStack {
             VStack {
                 scoreboardView()
-                HandView(title: "Dealer", hand: dealerHand, gameOver: gameOver)
-                HandView(title: "Player", hand: playerHand, gameOver: true)
+                HandView(title: "Dealer", hand: game.dealerHand, gameOver: game.gameOver)
+                HandView(title: "Player", hand: game.playerHand, gameOver: true)
                 Spacer()
                 actionButtons()
                 Spacer()
             }
-            
-            // ✅ Overlay for GameStatusView
-            GameStatusView(message: statusMessage, isVisible: $showGameStatus)
+
+            GameStatusView(message: game.statusMessage, isVisible: $showGameStatus)
+
+            if !hasGameStarted {
+                Color.black.opacity(0.8)
+                    .ignoresSafeArea()
+                    .transition(.opacity)
+
+                VStack {
+                    Text("♠️ Welcome to Blackjack")
+                        .font(.largeTitle)
+                        .bold()
+                        .foregroundColor(.white)
+                        .padding(.bottom, 20)
+
+                    Button(action: {
+                        withAnimation {
+                            hasGameStarted = true
+                        }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                            game.startGame()
+                        }
+                    }) {
+                        Text("Play")
+                            .font(.title)
+                            .padding(.horizontal, 40)
+                            .padding(.vertical, 20)
+                            .background(Color.green)
+                            .foregroundColor(.white)
+                            .cornerRadius(12)
+                    }
+                }
+                .transition(.scale)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color("Custom_Green"))
-        .onAppear(perform: startGame)
     }
-    
+
     // MARK: - Scoreboard View
-    
-    @ViewBuilder
+
     private func scoreboardView() -> some View {
         VStack {
             Text("Scoreboard History")
@@ -72,12 +69,11 @@ struct GameView: View {
                 .foregroundColor(.white.opacity(0.7))
                 .bold()
                 .padding(.bottom, 2)
-            
+
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 8) {
-                    ForEach(scoreHistory.indices, id: \.self) { index in
-                        let score = scoreHistory[index]
-                        
+                    ForEach(game.scoreHistory.indices, id: \.self) { index in
+                        let score = game.scoreHistory[index]
                         Text(score)
                             .font(.headline)
                             .bold()
@@ -98,185 +94,43 @@ struct GameView: View {
         .frame(maxWidth: .infinity)
         .padding(.top, 5)
     }
-    
+
     // MARK: - Action Buttons
-    
+
     @ViewBuilder
     private func actionButtons() -> some View {
-        if !gameOver && !hideButtons {
+        if !game.gameOver && !game.hideButtons {
             HStack(spacing: 20) {
                 GameActionButton(title: "Hit", color: .black) {
-                    playerHand.addCards(deck.deal(1))
-                    checkGameStatus()
+                    game.playerHit()
+                    if game.gameOver {
+                        showStatusThenReset()
+                    }
                 }
                 .frame(width: buttonWidth, height: buttonHeight)
-                
-                GameActionButton(title: "Stand", color: .black, action: {
-                    hideButtons = true
-                    dealerPlays()
-                })
+
+                GameActionButton(title: "Stand", color: .black) {
+                    game.playerStand {
+                        showStatusThenReset()
+                    }
+                }
                 .frame(width: buttonWidth, height: buttonHeight)
             }
             .padding(.top, 15)
-        } else if gameOver {
-            GameActionButton(title: "Deal", color: .black, action: resetGame)
-                .frame(width: dealButtonWidth, height: buttonHeight)
-        }
-    }
-    
-    // MARK: - Game Logic
-    
-    private func startGame() {
-        deck.resetDeck()
-        deck.shuffle()
-        
-        gameOver = false
-        hideButtons = false
-        
-        playerHand.reset()
-        dealerHand.reset()
-        
-        playerHand.addCards(deck.deal(2))
-        dealerHand.addCards(deck.deal(2))
-        
-        checkDealerBlackjack()
-    }
-    
-    private func checkDealerBlackjack() {
-        guard let faceUpCard = dealerHand.cards.last,
-              faceUpCard.rank == "Ace" || faceUpCard.value == 10 else {
-            checkGameStatus()
-            return
-        }
-        
-        hideButtons = true
-        updateStatus(dealerCheckingMessage)
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + dealerCheckDelay) {
-            let faceDownCard = dealerHand.cards.first
-            
-            if let card = faceDownCard, dealerHasBlackjack(card) {
-                gameOver = true
-                updateStatus(playerHand.isBlackjack ? bothBlackjackMessage : dealerHasBlackjackMessage)
-                
-                if !playerHand.isBlackjack {
-                    scoreHistory.append("D")
-                }
-                
-                DispatchQueue.main.asyncAfter(deadline: .now() + resetDelay) {
-                    resetGame()
-                }
-            } else {
-                updateStatus(initialMessage)
-                hideButtons = false
-                DispatchQueue.main.asyncAfter(deadline: .now() + messageDelay) {
-                    checkGameStatus()
-                }
+        } else if game.gameOver {
+            GameActionButton(title: "Deal", color: .black) {
+                game.startGame()
             }
+            .frame(width: dealButtonWidth, height: buttonHeight)
         }
     }
-    
-    /// Handles the dealer's turn after the player stands.
-    private func dealerPlays() {
-        hideButtons = true // ✅ Hide buttons as dealer plays
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { // ✅ Small delay for realism
-            while dealerHand.value < 17 { // ✅ Dealer hits until 17+
-                dealerHand.addCards(deck.deal(1))
-            }
-            
-            gameOver = true
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { // ✅ Show results after a short delay
-                if dealerHand.isBusted {
-                    updateStatus(dealerBustedMessage)
-                    scoreHistory.append("P") // ✅ Player wins
-                } else if dealerHand.value > playerHand.value {
-                    updateStatus(dealerWinsMessage)
-                    scoreHistory.append("D") // ✅ Dealer wins
-                } else if dealerHand.value == playerHand.value {
-                    updateStatus(tieMessage)
-                } else {
-                    updateStatus(playerWinsMessage)
-                    scoreHistory.append("P") // ✅ Player wins
-                }
-                
-                DispatchQueue.main.asyncAfter(deadline: .now() + resetDelay) {
-                    resetGame()
-                }
-            }
-        }
-    }
-    
-    /// Checks if the dealer has Blackjack using their face-down card.
-    private func dealerHasBlackjack(_ faceDownCard: Card) -> Bool {
-        guard dealerHand.cards.count > 1 else { return false } // ✅ Ensure there are at least 2 cards
-        
-        let faceUpCard = dealerHand.cards[1] // ✅ Dealer's visible card
-        
-        return (faceDownCard.rank == "Ace" && faceUpCard.value == 10) ||
-        (faceDownCard.value == 10 && faceUpCard.rank == "Ace")
-    }
-    
-    private func updateStatus(_ newMessage: String) {
-        statusMessage = newMessage
+
+    // MARK: - Status Message Flow
+
+    private func showStatusThenReset() {
         showGameStatus = true
-        
         DispatchQueue.main.asyncAfter(deadline: .now() + messageDelay) {
             showGameStatus = false
-        }
-    }
-    
-    /// Resets the game and starts a new round after a short delay.
-    private func resetGame() {
-        DispatchQueue.main.async {
-            self.message = initialMessage // ✅ Keep popup visible
-        }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + resetDelay) {
-            playerHand.reset()
-            dealerHand.reset() // ✅ Remove cards first, keep popup
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { // ✅ Wait a bit before hiding popup
-                message = "" // ✅ Hide the popup after cards are gone
-            }
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + dealNewCardsDelay + 0.8) {
-                startGame() // ✅ Start new round only after everything is clean
-            }
-        }
-    }
-    
-    /// Checks if the player has Blackjack or has busted.
-    private func checkGameStatus() {
-        if playerHand.isBlackjack {
-            gameOver = true
-            updateStatus("🎉 BLACKJACK! YOU WIN! 🃏🔥") // ✅ Shows emojis when player wins with BJ!
-            scoreHistory.append("BJ") // ✅ Track Blackjack wins separately
-            hideButtons = true
-        } else if playerHand.isBusted {
-            gameOver = true
-            updateStatus("💥 PLAYER BUSTED! 💀") // ✅ Now uses `updateStatus()`
-            scoreHistory.append("B") // ✅ Track Busts in scoreboard
-            hideButtons = true
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + messageDelay) {
-                clearTable() // ✅ Keeps the popup visible before removing cards
-            }
-        }
-        
-        if gameOver {
-            resetGame()
-        }
-    }
-    
-    /// Clears the table by removing cards but keeping the popup visible.
-    private func clearTable() {
-        playerHand.reset()
-        dealerHand.reset()
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + dealNewCardsDelay) {
-            resetGame() // ✅ Now resets AFTER clearing cards
         }
     }
 }

--- a/BlackjackGame/Views/HandView.swift
+++ b/BlackjackGame/Views/HandView.swift
@@ -50,6 +50,8 @@ struct HandView: View {
             HStack {
                 ForEach(hand.cards.indices, id: \.self) { index in
                     CardView(card: hand.cards[index], isFaceUp: gameOver || index != 0)
+                        .transition(.move(edge: .top)) // ✅ Slide down from top
+                        .animation(.easeOut.delay(Double(index) * 0.15), value: hand.cards.count) // ✅ Staggered animation
                 }
             }
         }

--- a/BlackjackGame/Views/NewViews/FloatingDevMenu.swift
+++ b/BlackjackGame/Views/NewViews/FloatingDevMenu.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct FloatingDevMenu: View {
+    @Binding var isVisible: Bool
+    @Binding var animationSpeed: AnimationSpeed
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 8) {
+            if isVisible {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Dev Menu")
+                        .font(.caption)
+                        .bold()
+                        .foregroundColor(.gray)
+
+                    Divider()
+                        .background(Color.white.opacity(0.2))
+
+                    Picker("Speed", selection: $animationSpeed) {
+                        ForEach(AnimationSpeed.allCases) { speed in
+                            Text(speed.rawValue.capitalized).tag(speed)
+                        }
+                    }
+                    .pickerStyle(SegmentedPickerStyle())
+                    .tint(.white) // ✅ clean + readable inside dark menu
+                    .frame(width: 180)
+                    
+                }
+                .padding()
+                .background(Color.black)
+                .opacity(0.7)
+                .cornerRadius(12)
+                .shadow(radius: 8)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+    
+            }
+
+            Button(action: {
+                withAnimation {
+                    isVisible.toggle()
+                }
+            }) {
+                Text("DEV")
+                    .font(.caption).bold()
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(.ultraThinMaterial) // ✅ glossy system feel
+                    .cornerRadius(10)
+                    .shadow(radius: 4)
+            }
+        }
+        .padding(.trailing, 16)
+        .padding(.bottom, 20)
+        .frame(width: 220, alignment: .trailing)
+    }
+}

--- a/BlackjackGame/Views/NewViews/HandCardStackView.swift
+++ b/BlackjackGame/Views/NewViews/HandCardStackView.swift
@@ -1,0 +1,26 @@
+// HandCardStackView.swift
+import SwiftUI
+
+struct HandCardStackView: View {
+    let cards: [Card]
+    let cardWidth: CGFloat
+
+    var body: some View {
+        let overlap: CGFloat = cardWidth * 0.25
+        let handWidth = cardWidth + CGFloat(max(0, cards.count - 1)) * overlap
+        let totalOffset = handWidth / 2 - cardWidth / 2
+
+        ZStack {
+            ForEach(cards.indices, id: \.self) { index in
+                CardView(card: cards[index], isFaceUp: true)
+                    .frame(width: cardWidth)
+                    .offset(x: CGFloat(index) * overlap - totalOffset)
+                    .transition(.asymmetric(
+                        insertion: .move(edge: .trailing).combined(with: .opacity),
+                        removal: .opacity
+                    ))
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: 200)
+    }
+}

--- a/BlackjackGame/Views/NewViews/NewGameView.swift
+++ b/BlackjackGame/Views/NewViews/NewGameView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct NewGameView: View {
+    @State private var showDevMenu = false
+    @State private var animationSpeed: AnimationSpeed = .medium
+    @State private var playerCards: [Card] = []
+    @State private var dealerCards: [Card] = []
+    
+    private let cardWidth: CGFloat = 100
+    
+    private let fullDeck: [Card] = [
+        Card(suit: "Spades", rank: "Ace", value: 11),
+        Card(suit: "Hearts", rank: "King", value: 10),
+        Card(suit: "Clubs", rank: "Six", value: 6),
+        Card(suit: "Diamonds", rank: "Three", value: 3),
+        Card(suit: "Diamonds", rank: "Queen", value: 10),
+        Card(suit: "Clubs", rank: "Seven", value: 7)
+    ]
+    
+    var body: some View {
+        ZStack {
+            VStack {
+                HandCardStackView(cards: dealerCards, cardWidth: cardWidth)
+                Spacer()
+                Text("Logo View Goes Here")
+                    .frame(height: 50)
+                Spacer()
+                HandCardStackView(cards: playerCards, cardWidth: cardWidth)
+                Button("Start Dealing") {
+                    dealOpeningCards()
+                }
+                .padding()
+                .background(Color.blue)
+                .foregroundColor(.white)
+                .cornerRadius(10)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color("Custom_Green"))
+        }
+        .overlay(alignment: .bottomTrailing) {
+            FloatingDevMenu(isVisible: $showDevMenu, animationSpeed: $animationSpeed)
+        }
+    }
+    
+    private func dealOpeningCards() {
+        let delayUnit = animationSpeed.delay
+        playerCards = []
+        dealerCards = []
+        func addCard(_ card: Card, to hand: Binding<[Card]>, after delay: TimeInterval) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                withAnimation {
+                    hand.wrappedValue.append(card)
+                }
+            }
+        }
+        addCard(fullDeck[0], to: $playerCards, after: delayUnit * 1)
+        addCard(fullDeck[4], to: $dealerCards, after: delayUnit * 2)
+        addCard(fullDeck[1], to: $playerCards, after: delayUnit * 3)
+        addCard(fullDeck[5], to: $dealerCards, after: delayUnit * 4)
+        addCard(fullDeck[2], to: $playerCards, after: delayUnit * 6)
+        addCard(fullDeck[3], to: $playerCards, after: delayUnit * 8)
+    }
+}


### PR DESCRIPTION
## What I did
- Created a reusable `HandCardStackView` to eliminate duplicated layout logic.
- Updated `PlayerCardAnimationView` and `DealerCardAnimationView` to use this new shared view.
- Preserved animation, overlapping offset logic, and centering behavior.

## Why
- This improves code clarity and maintainability.
- Easier to implement new features like splitting, highlighting active hand, or hiding dealer's first card.
