### PR TITLE
Add FloatingDevMenu with custom segmented control and styling

### DIFF
--- a/BlackjackGame/Views/DevMenuView.swift
+++ b/BlackjackGame/Views/DevMenuView.swift
@@ -11,15 +11,8 @@ struct DevMenuView: View {
                 .foregroundColor(.white.opacity(0.8))
                 .padding(.leading, 6)
 
-            Picker("", selection: $animationSpeed) {
-                ForEach(AnimationSpeed.allCases) { speed in
-                    Text(speed.rawValue.capitalized)
-                        .font(.caption2)
-                        .tag(speed)
-                }
-            }
-            .pickerStyle(SegmentedPickerStyle())
-            .frame(width: 160)
+            SegmentedControlView(selection: $animationSpeed)
+                .frame(width: 160)
         }
         .padding(8)
         .background(.ultraThinMaterial)
@@ -31,6 +24,5 @@ struct DevMenuView: View {
         .shadow(color: .black.opacity(0.15), radius: 4, x: 0, y: 2)
         .padding(.trailing, 16)
         .padding(.bottom, 24)
-    
     }
 }

--- a/BlackjackGame/Views/NewViews/FloatingDevMenu.swift
+++ b/BlackjackGame/Views/NewViews/FloatingDevMenu.swift
@@ -8,44 +8,35 @@ struct FloatingDevMenu: View {
         VStack(alignment: .trailing, spacing: 8) {
             if isVisible {
                 VStack(alignment: .leading, spacing: 12) {
-                    Text("Dev Menu")
-                        .font(.caption)
+                    Text("DEV MENU")
+                        .font(.caption2)
                         .bold()
-                        .foregroundColor(.gray)
+                        .foregroundColor(.white)
 
                     Divider()
                         .background(Color.white.opacity(0.2))
 
-                    Picker("Speed", selection: $animationSpeed) {
-                        ForEach(AnimationSpeed.allCases) { speed in
-                            Text(speed.rawValue.capitalized).tag(speed)
-                        }
-                    }
-                    .pickerStyle(SegmentedPickerStyle())
-                    .tint(.white) // ✅ clean + readable inside dark menu
-                    .frame(width: 180)
-                    
+                    SegmentedControlView(selection: $animationSpeed)
+                        .frame(width: 180)
                 }
                 .padding()
-                .background(Color.black)
-                .opacity(0.7)
+                .background(Color.black.opacity(0.7))
                 .cornerRadius(12)
                 .shadow(radius: 8)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
-    
             }
 
-            Button(action: {
+            Button {
                 withAnimation {
                     isVisible.toggle()
                 }
-            }) {
+            } label: {
                 Text("DEV")
                     .font(.caption).bold()
                     .foregroundColor(.white)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 8)
-                    .background(.ultraThinMaterial) // ✅ glossy system feel
+                    .background(Color.black)
                     .cornerRadius(10)
                     .shadow(radius: 4)
             }

--- a/BlackjackGame/Views/NewViews/SegmentedControlView.swift
+++ b/BlackjackGame/Views/NewViews/SegmentedControlView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct SegmentedControlView: View {
+    @Binding var selection: AnimationSpeed
+    
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(AnimationSpeed.allCases) { speed in
+                Button(action: {
+                    selection = speed
+                }) {
+                    Text(speed.rawValue.capitalized)
+                        .font(.caption2)
+                        .foregroundColor(.white)
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 12)
+                        .background(selection == speed ? .white.opacity(0.1) : .clear)
+                        .cornerRadius(8)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(.white.opacity(selection == speed ? 1 : 0), lineWidth: 1)
+                        )
+                }
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: selection)
+    }
+}


### PR DESCRIPTION
This PR introduces a floating developer menu aligned to the bottom-right of the screen.
- Adds `FloatingDevMenu` with toggle button
- Integrates `SegmentedControlView` to customize animation speed
- Uses consistent styling with black background and white foreground
- Applies smooth transitions and polished design matching the Blackjack UI style

This sets the foundation for future developer tools in the game.