### PR TITLE
Add dealer-style end-of-game card animation

### DIFF
--- a/BlackjackGame/Views/NewViews/FloatingDevMenu.swift
+++ b/BlackjackGame/Views/NewViews/FloatingDevMenu.swift
@@ -18,6 +18,16 @@ struct FloatingDevMenu: View {
 
                     SegmentedControlView(selection: $animationSpeed)
                         .frame(width: 180)
+                    Button("Game Completed") {
+                        NotificationCenter.default.post(name: .simulateGameEnd, object: nil)
+                    }
+                    .font(.caption2)
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
+                    .background(Color.red)
+                    .cornerRadius(8)
+                
                 }
                 .padding()
                 .background(Color.black.opacity(0.7))
@@ -45,4 +55,8 @@ struct FloatingDevMenu: View {
         .padding(.bottom, 20)
         .frame(width: 220, alignment: .trailing)
     }
+}
+
+extension Notification.Name {
+    static let simulateGameEnd = Notification.Name("simulateGameEnd")
 }

--- a/BlackjackGame/Views/NewViews/HandCardStackView.swift
+++ b/BlackjackGame/Views/NewViews/HandCardStackView.swift
@@ -3,27 +3,31 @@ import SwiftUI
 struct HandCardStackView: View {
     let cards: [Card]
     let cardWidth: CGFloat
+    var isGameOver: Bool = false
+    var isCollapsing: Bool = false // 👈 new param
 
     var body: some View {
         let overlap: CGFloat = cardWidth * 0.25
-        let extraCards = max(0, cards.count - 2)
-        let extraOffset = CGFloat(extraCards) * overlap / 2
-        let visibleCards = 2
-        let handWidth = cardWidth + CGFloat(max(0, visibleCards - 1)) * overlap
+        let handWidth = cardWidth + CGFloat(max(0, cards.count - 1)) * overlap
         let totalOffset = handWidth / 2 - cardWidth / 2
 
         ZStack {
             ForEach(cards) { card in
                 CardView(card: card, isFaceUp: true)
                     .frame(width: cardWidth)
-                    .offset(x: CGFloat(cards.firstIndex(of: card) ?? 0) * overlap - totalOffset)
+                    .offset(x: isCollapsing
+                            ? 0 // 👈 all cards collapse to center
+                            : CGFloat(cards.firstIndex(of: card) ?? 0) * overlap - totalOffset)
                     .transition(.asymmetric(
                         insertion: .move(edge: .trailing).combined(with: .opacity),
                         removal: .opacity
                     ))
             }
         }
-        .offset(x: cards.count > 2 ? -extraOffset : 0)
         .frame(maxWidth: .infinity, maxHeight: 200)
+        .offset(x: isGameOver ? -UIScreen.main.bounds.width : 0)
+        .opacity(isGameOver ? 0 : 1)
+        .animation(.easeInOut(duration: 0.6), value: isCollapsing)
+        .animation(.easeInOut(duration: 0.8), value: isGameOver)
     }
 }

--- a/BlackjackGame/Views/NewViews/NewGameView.swift
+++ b/BlackjackGame/Views/NewViews/NewGameView.swift
@@ -5,6 +5,8 @@ struct NewGameView: View {
     @State private var animationSpeed: AnimationSpeed = .medium
     @State private var playerCards: [Card] = []
     @State private var dealerCards: [Card] = []
+    @State private var isGameOver = false
+    @State private var isCollapsing = false
 
     private let cardWidth: CGFloat = 100
 
@@ -20,12 +22,12 @@ struct NewGameView: View {
     var body: some View {
         ZStack {
             VStack {
-                HandCardStackView(cards: dealerCards, cardWidth: cardWidth)
+                HandCardStackView(cards: dealerCards, cardWidth: cardWidth, isGameOver: isGameOver, isCollapsing: isCollapsing)
                 Spacer()
                 Text("Logo View Goes Here")
                     .frame(height: 50)
                 Spacer()
-                HandCardStackView(cards: playerCards, cardWidth: cardWidth)
+                HandCardStackView(cards: playerCards, cardWidth: cardWidth, isGameOver: isGameOver, isCollapsing: isCollapsing)
                 Spacer()
                 GameButton(title: "Start Dealing") {
                     dealOpeningCards()
@@ -37,6 +39,30 @@ struct NewGameView: View {
         }
         .overlay(alignment: .bottomTrailing) {
             FloatingDevMenu(isVisible: $showDevMenu, animationSpeed: $animationSpeed)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .simulateGameEnd)) { _ in
+            endGame()
+        }
+    }
+    
+    private func endGame() {
+        withAnimation {
+            isCollapsing = true
+        }
+
+        // Wait for collapse first
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            withAnimation {
+                isGameOver = true
+            }
+        }
+
+        // Wait for slide out, then reset cards
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            playerCards = []
+            dealerCards = []
+            isGameOver = false
+            isCollapsing = false
         }
     }
 


### PR DESCRIPTION
This PR adds a smooth and polished end-of-game animation:
- All cards collapse to center (like a real dealer stacks them).
- Then the stack slides off-screen with a fade.
- After the animation, cards are reset and game state is cleared.

Also ensures new UUIDs on every deal to avoid animation glitches.