### PR TITLE
feat: Add centered overlap logic for dealer cards and staged card dealing

### DIFF
--- a/BlackjackGame/Views/NewViews/HandCardStackView.swift
+++ b/BlackjackGame/Views/NewViews/HandCardStackView.swift
@@ -5,22 +5,52 @@ struct HandCardStackView: View {
     let cardWidth: CGFloat
     var isGameOver: Bool = false
     var isCollapsing: Bool = false
+    var isDealer: Bool = false
+
+    private let overlap: CGFloat = 30
+    private let spacing: CGFloat = 50 // spacing between first two dealer cards
 
     var body: some View {
-        let overlap: CGFloat = isCollapsing ? cardWidth * 0.05 : cardWidth * 0.25
-        let extraCards = max(0, cards.count - 2)
-        let extraOffset = CGFloat(extraCards) * overlap / 2
-        let visibleCards = 2
-        let handWidth = cardWidth + CGFloat(max(0, visibleCards - 1)) * overlap
-        let totalOffset = handWidth / 2 - cardWidth / 2
+        let centerGapOffset: CGFloat = {
+            if isDealer {
+                if cards.count <= 2 {
+                    // First two cards spaced evenly
+                    return (cardWidth * 2 + spacing) / 2
+                } else {
+                    // For 3 or more cards, treat all with overlap
+                    let totalWidth = cardWidth + CGFloat(cards.count - 1) * overlap
+                    return totalWidth / 2 - cardWidth / 2
+                }
+            } else {
+                let totalWidth = cardWidth + CGFloat(max(0, cards.count - 1)) * overlap
+                return totalWidth / 2 - cardWidth / 2
+            }
+        }()
 
         ZStack {
-            ForEach(cards) { card in
-                let index = cards.firstIndex(of: card) ?? 0
-                let isFixed = index < 2
-                let xOffset: CGFloat = isFixed
-                    ? CGFloat(index) * overlap - totalOffset
-                    : CGFloat(index) * overlap - totalOffset
+            ForEach(Array(cards.enumerated()), id: \.element.id) { index, card in
+                let xOffset: CGFloat = {
+                    if isCollapsing {
+                        return 0
+                    }
+                    if isDealer {
+                        if cards.count <= 2 {
+                            switch index {
+                            case 0:
+                                return -((cardWidth + spacing) / 2)
+                            case 1:
+                                return ((cardWidth + spacing) / 2)
+                            default:
+                                return 0 // shouldn't happen
+                            }
+                        } else {
+                            // Use overlap layout for all dealer cards
+                            return CGFloat(index) * overlap - centerGapOffset
+                        }
+                    } else {
+                        return CGFloat(index) * overlap - centerGapOffset
+                    }
+                }()
 
                 CardView(card: card, isFaceUp: true)
                     .frame(width: cardWidth)
@@ -31,10 +61,19 @@ struct HandCardStackView: View {
                     ))
             }
         }
-        .offset(x: isGameOver ? -UIScreen.main.bounds.width : (cards.count > 2 ? -extraOffset : 0))
-        .opacity(isGameOver ? 0 : 1)
-        .animation(.easeInOut(duration: 0.6), value: isCollapsing)
-        .animation(.easeInOut(duration: 0.8), value: isGameOver)
         .frame(maxWidth: .infinity, maxHeight: 200)
+        .offset(x: {
+            if isDealer && cards.count > 2 {
+                let cardLeft = CGFloat(cards.count - 2)
+                let totalOverlap = cardWidth/overlap
+                let shadowBuffer = 3.0
+                let newX = ((totalOverlap - shadowBuffer) * cardLeft) / 2
+                return newX
+            } else {
+                return 0
+            }
+        }())
+        .animation(isDealer ? .easeInOut(duration: 0.6) : .none, value: isCollapsing)
+        .animation(.easeInOut(duration: 0.8), value: isGameOver)
     }
 }

--- a/BlackjackGame/Views/NewViews/NewGameView.swift
+++ b/BlackjackGame/Views/NewViews/NewGameView.swift
@@ -7,6 +7,7 @@ struct NewGameView: View {
     @State private var dealerCards: [Card] = []
     @State private var isGameOver = false
     @State private var isCollapsing = false
+    
 
     private let cardWidth: CGFloat = 100
 
@@ -16,18 +17,34 @@ struct NewGameView: View {
         Card(suit: "Clubs", rank: "Six", value: 6),
         Card(suit: "Diamonds", rank: "Three", value: 3),
         Card(suit: "Diamonds", rank: "Queen", value: 10),
-        Card(suit: "Clubs", rank: "Seven", value: 7)
+        Card(suit: "Clubs", rank: "Seven", value: 7),
+        Card(suit: "Spades", rank: "Five", value: 5),
+        Card(suit: "Hearts", rank: "Two", value: 2),
+        Card(suit: "Clubs", rank: "Nine", value: 9),     // Added
+        Card(suit: "Hearts", rank: "Four", value: 4)     // Added
     ]
 
     var body: some View {
         ZStack {
             VStack {
-                HandCardStackView(cards: dealerCards, cardWidth: cardWidth, isGameOver: isGameOver, isCollapsing: isCollapsing)
+                HandCardStackView(
+                    cards: dealerCards,
+                    cardWidth: cardWidth,
+                    isGameOver: isGameOver,
+                    isCollapsing: isCollapsing,
+                    isDealer: true
+                )
                 Spacer()
                 Text("Logo View Goes Here")
                     .frame(height: 50)
                 Spacer()
-                HandCardStackView(cards: playerCards, cardWidth: cardWidth, isGameOver: isGameOver, isCollapsing: isCollapsing)
+                HandCardStackView(
+                    cards: playerCards,
+                    cardWidth: cardWidth,
+                    isGameOver: isGameOver,
+                    isCollapsing: isCollapsing,
+                    isDealer: false
+                )
                 Spacer()
                 GameButton(title: "Start Dealing") {
                     dealOpeningCards()
@@ -85,6 +102,13 @@ struct NewGameView: View {
         addCard(fullDeck[5], to: $dealerCards, after: delayUnit * 4)
         addCard(fullDeck[2], to: $playerCards, after: delayUnit * 6)
         addCard(fullDeck[3], to: $playerCards, after: delayUnit * 8)
+        
+        
+        // Additional dealer cards (after player is done)
+        addCard(fullDeck[6], to: $dealerCards, after: delayUnit * 10)
+        addCard(fullDeck[7], to: $dealerCards, after: delayUnit * 12)
+        addCard(fullDeck[8], to: $dealerCards, after: delayUnit * 14)
+        addCard(fullDeck[9], to: $dealerCards, after: delayUnit * 16)
     }
 
     private func clone(_ card: Card) -> Card {


### PR DESCRIPTION
This PR introduces the following improvements:
 - Dealer overlap logic:
Dealer’s first two cards now have a defined gap and are centered. Additional cards overlap smoothly and stay visually centered across the screen.
- Card stacking logic:
Logic added to center dealer hands dynamically depending on the number of cards.
-  New dealer cards after player turn:
Added two more dealer cards with animated delays to simulate the dealer drawing after the player is done.
- Minor tweaks:
Updated HandCardStackView to better support clean animation and maintain visual balance.
Adjusted fullDeck to include 10 cards.