### PR TITLE
refactor: convert Card to class and add dealing lock

### DIFF
--- a/BlackjackGame/Models/Card.swift
+++ b/BlackjackGame/Models/Card.swift
@@ -7,13 +7,15 @@
 
 import Foundation
 
-struct Card: Identifiable, Equatable {
+final class Card: Identifiable, ObservableObject {
     let id = UUID()
     let suit: String
     let rank: String
     let value: Int
-    
-    var description: String {
-        "\(rank) of \(suit)"
+
+    init(suit: String, rank: String, value: Int) {
+        self.suit = suit
+        self.rank = rank
+        self.value = value
     }
 }

--- a/BlackjackGame/Views/CenteredCardStackView.swift
+++ b/BlackjackGame/Views/CenteredCardStackView.swift
@@ -1,5 +1,5 @@
 //
-//  CenteredCardStackView.swift
+//  FanCardsView.swift
 //  BlackjackGame
 //
 //  Created by Jonni Akesson on 2025-06-05.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct CenteredCardStackView: View {
+struct FanCardsView: View {
     let height: CGFloat
     let cards: [Card]
     let cardWidth: CGFloat


### PR DESCRIPTION
- Changed Card from struct to class to support future Firebase integration
- Renamed CenteredCardStackView to FanCardsView for better semantic clarity
- Added isDealing flag to prevent overlapping deal animations
- Simplified card dealing functions and reduced risk of duplicate appends